### PR TITLE
Remote Keyset storage and retrieval support

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,7 @@ How to compute or verify a MAC (Message Authentication Code)
 Here is an example of how to sign or verify a digital signature:
 
 ```clojure
-(:require [tinklj.config :refer :all]
-          [tinklj.primitives :as primitives]
+(:require [tinklj.primitives :as primitives]
           [tinklj.keys.keyset-handle :as keyset-handles]
           [tinklj.signature.digital-signature :refer [sign verify])
 
@@ -240,6 +239,18 @@ Here is an example of how to sign or verify a digital signature:
         data)
 ```
 
+## Key Rotation
+To complete key rotation you need a keyset-handle that contains the keyset that should be rotated, and a specification of the new key via the KeyTemplate map for example :aes128-gcm.
+
+```clojure
+(:require [tinklj.keys.keyset-handle :as keyset-handles]
+          [tinklj.keysets.keyset-storage :as keyset-storage])
+
+(def keyset-handle (keyset-handles/generate-new :aes128-gcm)) ;; existing keyset
+(def keyset-template (:hmac-sha256-128bittag keyset-handles/key-templates)) ;; template for the new key
+
+(keyset-storage/rotate-keyset-handle keyset-handle keyset-template)
+```
 
 ## FAQ
 
@@ -257,14 +268,14 @@ Based on the available feature list defined [here](https://github.com/google/tin
 - [x] Symmetric key encryption
 - [x] Storing keysets
 - [x] Loading existing keysets
-- [ ] Storing and loading encrypted keysets
+- [x] Storing and loading encrypted keysets
 - [x] Deterministic symmetric key encryption
 - [ ] Streaming symmetric key encryption
 - [x] MAC codes
 - [x] Digital signatures
 - [ ] Hybrid encryption
 - [ ] Envelope encryption
-- [ ] Key rotation
+- [x] Key rotation
 
 # Contributions
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ compile 'tinklj:tinklj:0.1.0-SNAPSHOT'
 </dependency>
 ```
 
-# Symmetric Encryption
+# Getting Started
 
-The best way to find the use cases for the encryption techniques is to check the [Acceptance Tests](https://github.com/perkss/tinklj/blob/master/test/tinklj/acceptance/symmetric_key_encryption_test.clj).
+The best way to find example use cases for the encryption techniques is to check the [Acceptance Tests](https://github.com/perkss/tinklj/blob/master/test/tinklj/acceptance/symmetric_key_encryption_test.clj).
 
 ## Initialize Tinklj
 
@@ -78,9 +78,37 @@ Once you have generated the keyset you can store it down for future use.
 Cleartext and encrypted keysets can be stored. Obviously encrypted is recommended.
 
 ```clojure
-(:require [tinklj.keysets.keyset-storage :as keyset-storage])
+(:require [tinklj.keys.keyset-handle :as keyset-handles]
+          [tinklj.keysets.keyset-storage :as keyset-storage])
+
+(def filename "my_keyset.json")
+(def keyset-handle (keyset-handles/generate-new :aes128-gcm)
 
 (keyset-storage/write-clear-text-keyset-handle keyset-handle filename)
+```
+
+Tinklj supports encrypting keysets with master keys stored in a remote key management systems. Lets see how to write these remote KMS keys.
+
+```clojure
+(:require [tinklj.keys.keyset-handle :as keyset-handles]
+          [tinklj.keysets.keyset-storage :as keyset-storage]
+          [tinklj.keysets.integration.gcp-kms-client :refer [gcp-kms-client])
+
+
+;; Generate the key material...
+(def keyset-handle (keyset-handles/generate-new :aes128-gcm)
+
+;; and write it to a file...
+(def filename "my_keyset.json")
+;; encrypted with the this key in GCP KMS
+(def master-key-uri = "gcp-kms://projects/tinklj-examples/locations/global/keyRings/foo/cryptoKeys/bar")
+(def kms-client (gcp-kms-client))
+
+(keyset-storage/write-remote-kms-keyset-handle
+                    keyset-handle
+                    kms-client
+                    filename
+                    master-key-uri)
 ```
 
 ## Loading Existing Keysets
@@ -93,6 +121,25 @@ Once the keyset is stored it can be reloaded as follows:
 (keyset-storage/load-clear-text-keyset-handle filename)
 ```
 
+Loading remote encrypted keys:
+
+```clojure
+(:require [tinklj.keys.keyset-handle :as keyset-handles]
+          [tinklj.keysets.keyset-storage :as keyset-storage]
+          [tinklj.keysets.integration.gcp-kms-client :refer [gcp-kms-client])
+
+
+(def filename "my_keyset.json")
+;; encrypted with the this key in GCP KMS
+(def master-key-uri = "gcp-kms://projects/tinklj-examples/locations/global/keyRings/foo/cryptoKeys/bar")
+(def kms-client (gcp-kms-client))
+
+(keyset-storage/load-remote-kms-keyset-handle
+                    kms-client
+                    filename
+                    master-key-uri)
+```
+
 
 ## Obtaining and Using Primitives
 
@@ -102,20 +149,44 @@ We then get the primitive of the keyset-handle and can use this to encrypt and d
 ```
 
 
-## Authenticated Encryption with Associated Data
+## Symmetric Key Encryption
+#### Authenticated Encryption with Associated Data
 ```clojure
-(:require [tinklj.encryption.aead :refer [encrypt decrypt])
+(:require [tinklj.encryption.aead :refer [encrypt decrypt]
+          [tinklj.keys.keyset-handle :as keyset-handle]
+          [tinklj.primitives :as primitives])
 
-(encrypt aead (.getBytes data-to-encrypt) aad)
-(decrypt aead encrypted aad)
+;; 1. Generate the key material.
+(def keyset-handle (keyset-handle/generate-new :aes128-gcm))
+
+;; 2. Get the primitive.
+(def aead (deterministic handle))
+
+;; 3. Use the primitive to encrypt a plaintext,
+(def ciphertext (encrypt aead (.getBytes data-to-encrypt) aad))
+
+;; ... or to decrypt a ciphertext.
+(def decrypted (decrypt aead ciphertext aad))
 ```
 
-## Deterministic Authenticated Encryption with Associated Data
+## Deterministic Symmetric Key Encryption
+#### Deterministic Authenticated Encryption with Associated Data
 ```clojure
-(:require [tinklj.encryption.daead :refer [encrypt decrypt])
+(:require [tinklj.encryption.daead :refer [encrypt decrypt]
+          [tinklj.keys.keyset-handle :as keyset-handle])
 
-(encrypt aead (.getBytes data-to-encrypt) aad)
-(decrypt aead encrypted aad)
+
+;; 1. Generate the key material.
+(def keyset-handle (keyset-handle/generate-new :aes256-siv))
+
+;; 2. Get the primitive.
+(def daead (deterministic keyset-handle))
+
+;; 3. Use the primitive to deterministically encrypt a plaintext,
+(def ciphertext (encrypt daead (.getBytes data-to-encrypt) aad))
+
+;; ... or to deterministically decrypt a ciphertext.
+(def decrypted (decrypt daead ciphertext aad))
 ```
 
 ## Message Authentication Code
@@ -123,11 +194,21 @@ We then get the primitive of the keyset-handle and can use this to encrypt and d
 How to compute or verify a MAC (Message Authentication Code)
 
 ```clojure
-(:require [tinklj.mac.message-authentication-code :refer :as mac)
+(:require [tinklj.primitives :as primitives]
+          [tinklj.keys.keyset-handle :as keyset-handles]
+          [tinklj.mac.message-authentication-code :as mac])
 
+;; 1. Generate the key material.
+(def keyset-handle (keyset-handles/generate-new :hmac-sha256-128bittag))
 
-(mac/compute mac data)
-(mac/verify mac tag data)
+;; 2. Get the primitive.
+(def mac-primitive (primitives/mac keyset-handle))
+
+;; 3. Use the primitive to compute a tag,
+(mac/compute mac-primitive data)
+
+;; ... or to verify a tag.
+(mac/verify mac-primitive tag data)
 ```
 
 ## Digital Signatures

--- a/src/tinklj/config.clj
+++ b/src/tinklj/config.clj
@@ -15,12 +15,12 @@
     (register :mac)"
   [& config-type]
   (case (first config-type)
-   :aead (AeadConfig/register)
-   :daead (DeterministicAeadConfig/register)
-   :mac (MacConfig/register)
-   :signature (SignatureConfig/register)
-   :streaming (StreamingAeadConfig/register)
-   (TinkConfig/register)))
+    :aead (AeadConfig/register)
+    :daead (DeterministicAeadConfig/register)
+    :mac (MacConfig/register)
+    :signature (SignatureConfig/register)
+    :streaming (StreamingAeadConfig/register)
+    (TinkConfig/register)))
 
 (defn register-key-manager
   "Register custom implementation of key manager"

--- a/src/tinklj/keysets/integration/aws_kms_client.clj
+++ b/src/tinklj/keysets/integration/aws_kms_client.clj
@@ -1,0 +1,6 @@
+(ns tinklj.keysets.integration.aws-kms-client
+  (:import (com.google.crypto.tink.integration.awskms AwsKmsClient)))
+
+(defn aws-kms-client
+  ([] (AwsKmsClient.))
+  ([uri] (AwsKmsClient. uri)))

--- a/src/tinklj/keysets/integration/gcp_kms_client.clj
+++ b/src/tinklj/keysets/integration/gcp_kms_client.clj
@@ -1,0 +1,6 @@
+(ns tinklj.keysets.integration.gcp-kms-client
+  (:import (com.google.crypto.tink.integration.gcpkms GcpKmsClient)))
+
+(defn gcp-kms-client
+  ([] (GcpKmsClient.))
+  ([uri] (GcpKmsClient. uri)))

--- a/src/tinklj/keysets/integration/kms_client.clj
+++ b/src/tinklj/keysets/integration/kms_client.clj
@@ -1,0 +1,18 @@
+(ns tinklj.keysets.integration.kms-client
+  (:import (com.google.crypto.tink KmsClient)))
+
+(defn does-support
+  [^KmsClient client uri]
+  (.doesSupport client uri))
+
+(defn with-credentials
+  [^KmsClient client credential-path]
+  (.withCredentials client credential-path))
+
+(defn with-default-credentials
+  [^KmsClient client]
+  (.withDefaultCredentials client))
+
+(defn get-aead
+  [^KmsClient client key-uri]
+  (.getAead client key-uri))

--- a/src/tinklj/keysets/keyset_storage.clj
+++ b/src/tinklj/keysets/keyset_storage.clj
@@ -1,5 +1,5 @@
 (ns tinklj.keysets.keyset-storage
-  (:import (com.google.crypto.tink CleartextKeysetHandle JsonKeysetWriter JsonKeysetReader KeysetHandle KmsClient))
+  (:import (com.google.crypto.tink CleartextKeysetHandle JsonKeysetWriter JsonKeysetReader KeysetHandle KmsClient KeysetManager))
   (:require [clojure.java.io :as io]
             [tinklj.keysets.integration.kms-client :as client]))
 
@@ -25,3 +25,9 @@
   [^KmsClient kms-client filename master-key-uri]
   (KeysetHandle/read (JsonKeysetReader/withFile (io/file filename))
                      (client/get-aead kms-client master-key-uri)))
+
+(defn rotate-keyset-handle
+  [keyset-handle key-template]
+  (-> (KeysetManager/withKeysetHandle keyset-handle)
+      (.rotate key-template)
+      (.getKeysetHandle)))

--- a/src/tinklj/keysets/keyset_storage.clj
+++ b/src/tinklj/keysets/keyset_storage.clj
@@ -1,15 +1,27 @@
 (ns tinklj.keysets.keyset-storage
-  (:import (com.google.crypto.tink CleartextKeysetHandle JsonKeysetWriter JsonKeysetReader))
-  (:require [clojure.java.io :as io] ))
+  (:import (com.google.crypto.tink CleartextKeysetHandle JsonKeysetWriter JsonKeysetReader KeysetHandle KmsClient))
+  (:require [clojure.java.io :as io]
+            [tinklj.keysets.integration.kms-client :as client]))
 
 (defn write-clear-text-keyset-handle
   [keyset-handle filename]
   (CleartextKeysetHandle/write
-    keyset-handle
-    (JsonKeysetWriter/withFile (io/file filename))))
+   keyset-handle
+   (JsonKeysetWriter/withFile (io/file filename))))
 
 (defn load-clear-text-keyset-handle
   [filename]
   (CleartextKeysetHandle/read
-    (JsonKeysetReader/withFile
-      (io/file filename))))
+   (JsonKeysetReader/withFile
+    (io/file filename))))
+
+(defn write-remote-kms-keyset-handle
+  [^KeysetHandle keyset-handle ^KmsClient kms-client filename master-key-uri]
+  (.write keyset-handle
+          (JsonKeysetWriter/withFile (io/file filename))
+          (client/get-aead kms-client master-key-uri)))
+
+(defn load-remote-kms-keyset-handle
+  [^KmsClient kms-client filename master-key-uri]
+  (KeysetHandle/read (JsonKeysetReader/withFile (io/file filename))
+                     (client/get-aead kms-client master-key-uri)))

--- a/src/tinklj/signature/digital_signature.clj
+++ b/src/tinklj/signature/digital_signature.clj
@@ -11,7 +11,7 @@
 (defn verify
   [public-keyset-handle signature data]
   (let [^PublicKeyVerify public-key-verifier (digital-signature-verification
-                                               public-keyset-handle)]
+                                              public-keyset-handle)]
     (.verify public-key-verifier
              signature
              (.getBytes data))))

--- a/test/tinklj/acceptance/digital_signature_test.clj
+++ b/test/tinklj/acceptance/digital_signature_test.clj
@@ -14,8 +14,8 @@
     (let [data "Secret Data to be Signed"
           private-keyset-handle (keyset-handles/generate-new :ecdsa-p256)
           signature (sut/sign
-                      private-keyset-handle
-                      data)
+                     private-keyset-handle
+                     data)
           public-key-set-handle (get-public-keyset-handle private-keyset-handle)
           verify (sut/verify public-key-set-handle
                              signature

--- a/test/tinklj/acceptance/symmetric_deterministic_key_encryption_test.clj
+++ b/test/tinklj/acceptance/symmetric_deterministic_key_encryption_test.clj
@@ -10,15 +10,15 @@
 (deftest symmetric-deterministic-key-encryption
 
   (testing "Deterministic Encryption and Decryption"
-      (let [aad "salt"
-            handle (keyset/generate-new :aes256-siv)
-            primitive (deterministic handle)
-            encrypted-data (sut/encrypt primitive
-                                        "Secret"
-                                        aad)
-            decrypted-data (sut/decrypt primitive
-                                        encrypted-data
-                                        aad)]
-        (is (= "Secret"
-               (String. decrypted-data))))))
+    (let [aad "salt"
+          handle (keyset/generate-new :aes256-siv)
+          primitive (deterministic handle)
+          encrypted-data (sut/encrypt primitive
+                                      "Secret"
+                                      aad)
+          decrypted-data (sut/decrypt primitive
+                                      encrypted-data
+                                      aad)]
+      (is (= "Secret"
+             (String. decrypted-data))))))
 

--- a/test/tinklj/config_test.clj
+++ b/test/tinklj/config_test.clj
@@ -8,8 +8,8 @@
       (is (nil? (sut/register thing)))))
 
   (testing "Config without a type"
-      (is (nil? (sut/register))))
+    (is (nil? (sut/register))))
 
   (testing "Defaults to Standard config"
-      (is (nil? (sut/register :foobar)))))
+    (is (nil? (sut/register :foobar)))))
 

--- a/test/tinklj/keysets/integration/aws_kms_client_test.clj
+++ b/test/tinklj/keysets/integration/aws_kms_client_test.clj
@@ -1,0 +1,18 @@
+(ns tinklj.keysets.integration.aws-kms-client-test
+  (:require [clojure.test :refer [deftest is testing]])
+  (:require [tinklj.keysets.integration.kms-client :as client]
+            [tinklj.keysets.integration.aws-kms-client :refer [aws-kms-client]])
+  (:import (com.google.crypto.tink.integration.awskms AwsKmsClient)))
+
+(deftest aws-kms-client-instance-test
+  (testing "A new instance of the AWS client is created"
+    (is (= AwsKmsClient (type (aws-kms-client))))))
+
+(deftest aws-kms-client-instance-uri-test
+  (testing "A new instance of the AWS client with uri is created"
+    (is (= AwsKmsClient (type (aws-kms-client "aws-kms://"))))))
+
+(deftest aws-kms-client-does-support-test
+  (testing "A new instance of the AWS client with uri is created"
+    (let [client (aws-kms-client)]
+      (is (true? (client/does-support client "aws-kms://"))))))

--- a/test/tinklj/keysets/integration/gcp_kms_client_test.clj
+++ b/test/tinklj/keysets/integration/gcp_kms_client_test.clj
@@ -1,0 +1,18 @@
+(ns tinklj.keysets.integration.gcp-kms-client-test
+  (:require [clojure.test :refer [deftest testing is]])
+  (:require [tinklj.keysets.integration.gcp-kms-client :refer [gcp-kms-client]]
+            [tinklj.keysets.integration.kms-client :as client])
+  (:import (com.google.crypto.tink.integration.gcpkms GcpKmsClient)))
+
+(deftest gcp-kms-client-test-instance
+  (testing "A new instance of the GCP client is created"
+    (is (= GcpKmsClient (type (gcp-kms-client))))))
+
+(deftest gcp-kms-client-test-instance-uri
+  (testing "A new instance of the GCP client with uri is created"
+    (is (= GcpKmsClient (type (gcp-kms-client "gcp-kms://"))))))
+
+(deftest gcp-kms-client-does-support-test
+  (testing "A new instance of the GCP client with uri is created"
+    (let [client (gcp-kms-client)]
+      (is (true? (client/does-support client "gcp-kms://"))))))

--- a/test/tinklj/keysets/keyset_storage_test.clj
+++ b/test/tinklj/keysets/keyset_storage_test.clj
@@ -16,3 +16,11 @@
           keyset (keyset-storage/load-clear-text-keyset-handle filename)]
       (is (= KeysetHandle (type keyset)))
       (io/delete-file filename))))
+
+
+(deftest rotate-should-add-new-key-and-set-primary-key-id
+  (testing "Rotate key should add new and set a primary key id")
+  (let [keyset-handle (keyset-handles/generate-new :aes128-gcm)
+        keyset-template (:hmac-sha256-128bittag keyset-handles/key-templates)
+        keyset-info (.getKeysetInfo (keyset-storage/rotate-keyset-handle keyset-handle keyset-template))]
+    (is (= 2 (.getKeyInfoCount keyset-info)))))

--- a/test/tinklj/keysets/keyset_storage_test.clj
+++ b/test/tinklj/keysets/keyset_storage_test.clj
@@ -17,7 +17,6 @@
       (is (= KeysetHandle (type keyset)))
       (io/delete-file filename))))
 
-
 (deftest rotate-should-add-new-key-and-set-primary-key-id
   (testing "Rotate key should add new and set a primary key id")
   (let [keyset-handle (keyset-handles/generate-new :aes128-gcm)


### PR DESCRIPTION
@lamp for reference this is what I am working on now. 
https://github.com/google/tink/blob/master/docs/JAVA-HOWTO.md#loading-existing-keysets

To add a api for the aws and gcp clients for kms. 

Remote keyset storage #18