### PR TITLE
Add Hybrid test for encryption. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,45 @@ Here is an example of how to sign or verify a digital signature:
         data)
 ```
 
+## Hybrid Encryption
+
+To encrypt or decrypt using a [combination of public key encryption and symmetric key encryption](https://github.com/google/tink/blob/master/docs/PRIMITIVES.md#hybrid-encryption) one can use the following:
+
+```clojure
+(:require  [tinklj.config :refer [register]]
+           [tinklj.keys.keyset-handle :as keyset]
+           [tinklj.primitives :as primitives]
+           [tinklj.encryption.aead :refer [encrypt decrypt]])
+
+(register)
+
+;; 1. Generate the private key material.
+(def private-keyset-handle (keyset/generate-new :ecies-p256-hkdf-hmac-sha256-aes128-gcm))
+
+;;  Obtain the public key material.
+(def public-keyset-handle (keyset/get-public-keyset-handle private-keyset-handle))
+
+;; ENCRYPTING
+
+;; 2. Get the primitive.
+(def hybrid-encrypt (primitives/hybrid-encryption public-keyset-handle))
+
+;; 3. Use the primitive.
+(def encrypted-data (encrypt hybrid-encrypt
+                                 (.getBytes plain-text)
+                                 aad))
+;; DECRYPTING
+
+;;  2. Get the primitive.
+(def hybrid-decrypt (primitives/hybrid-decryption private-keyset-handle))
+
+;; 3. Use the primitive.
+(def decrypted-data (decrypt hybrid-decrypt
+                                 encrypted-data
+                                 aad))
+```
+
+
 ## Key Rotation
 To complete key rotation you need a keyset-handle that contains the keyset that should be rotated, and a specification of the new key via the KeyTemplate map for example :aes128-gcm.
 
@@ -278,7 +317,7 @@ Based on the available feature list defined [here](https://github.com/google/tin
 - [ ] Streaming symmetric key encryption
 - [x] MAC codes
 - [x] Digital signatures
-- [ ] Hybrid encryption
+- [x] Hybrid encryption
 - [ ] Envelope encryption
 - [x] Key rotation
 

--- a/src/tinklj/encryption/daead.clj
+++ b/src/tinklj/encryption/daead.clj
@@ -2,10 +2,10 @@
 
 (defn encrypt [handle data salt]
   (.encryptDeterministically handle
-                             (.getBytes data)
-                             (.getBytes salt)))
+                             data
+                             salt))
 
 (defn decrypt [handle encrypted-data salt]
   (.decryptDeterministically handle
                              encrypted-data
-                             (.getBytes salt)))
+                             salt))

--- a/test/tinklj/acceptance/digital_signature_test.clj
+++ b/test/tinklj/acceptance/digital_signature_test.clj
@@ -11,13 +11,13 @@
 (deftest digital-signature-sign-and-verify
 
   (testing "How to compute or verify a Mac (Message Authentication Code)"
-    (let [data "Secret Data to be Signed"
+    (let [plain-text "Secret Data to be Signed"
           private-keyset-handle (keyset-handles/generate-new :ecdsa-p256)
           signature (sut/sign
                      private-keyset-handle
-                     data)
+                     plain-text)
           public-key-set-handle (get-public-keyset-handle private-keyset-handle)
           verify (sut/verify public-key-set-handle
                              signature
-                             data)]
+                             plain-text)]
       (is (not (= GeneralSecurityException verify))))))

--- a/test/tinklj/acceptance/hybrid_encryption_test.clj
+++ b/test/tinklj/acceptance/hybrid_encryption_test.clj
@@ -1,0 +1,28 @@
+(ns tinklj.acceptance.hybrid-encryption-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [tinklj.config :refer [register]]
+            [tinklj.keys.keyset-handle :as keyset]
+            [tinklj.primitives :as primitives]
+            [tinklj.encryption.aead :refer [encrypt decrypt]]))
+
+(register)
+
+(deftest hybrid-encryption-test
+
+  (testing "Hybrid Encryption using Public and Private Key"
+    (let [aad (.getBytes "salt")
+          plain-text "Secret"
+          private-keyset-handle (keyset/generate-new :ecies-p256-hkdf-hmac-sha256-aes128-gcm)
+          public-keyset-handle (keyset/get-public-keyset-handle private-keyset-handle)
+          hybrid-encrypt (primitives/hybrid-encryption public-keyset-handle)
+          hybrid-decrypt (primitives/hybrid-decryption private-keyset-handle)
+          encrypted-data (encrypt hybrid-encrypt
+                                      (.getBytes plain-text)
+                                      aad)
+          decrypted-data (decrypt hybrid-decrypt
+                                      encrypted-data
+                                      aad)]
+      (is (= plain-text
+             (String. decrypted-data))))))
+
+

--- a/test/tinklj/acceptance/message_authentication_code_test.clj
+++ b/test/tinklj/acceptance/message_authentication_code_test.clj
@@ -11,14 +11,14 @@
 (deftest message-authentication-code
 
   (testing "How to compute or verify a Mac (Message Authentication Code)"
-    (let [secret-data (.getBytes "Secret data")
+    (let [plain-text (.getBytes "Secret data")
           keyset-handle (keyset-handles/generate-new :hmac-sha256-128bittag)
           mac (primitives/mac keyset-handle)
           tag (sut/compute mac
-                           secret-data)
+                           plain-text)
           verify (sut/verify mac
                              tag
-                             secret-data)]
+                             plain-text)]
       (is (not (= GeneralSecurityException verify))))))
 
 (deftest invalid-message-authentication-code

--- a/test/tinklj/acceptance/symmetric_deterministic_key_encryption_test.clj
+++ b/test/tinklj/acceptance/symmetric_deterministic_key_encryption_test.clj
@@ -10,15 +10,16 @@
 (deftest symmetric-deterministic-key-encryption
 
   (testing "Deterministic Encryption and Decryption"
-    (let [aad "salt"
+    (let [aad (.getBytes "salt")
+          plain-text "Secret"
           handle (keyset/generate-new :aes256-siv)
           primitive (deterministic handle)
           encrypted-data (sut/encrypt primitive
-                                      "Secret"
+                                      (.getBytes plain-text)
                                       aad)
           decrypted-data (sut/decrypt primitive
                                       encrypted-data
                                       aad)]
-      (is (= "Secret"
+      (is (= plain-text
              (String. decrypted-data))))))
 

--- a/test/tinklj/acceptance/symmetric_key_encryption_test.clj
+++ b/test/tinklj/acceptance/symmetric_key_encryption_test.clj
@@ -10,14 +10,14 @@
 (deftest symmetric-key-encryption
   (testing "Symmetric key encryption"
 
-    (let [secret-data "Secret data"
+    (let [plain-text "Secret data"
           keyset-handle (keyset-handles/generate-new :aes128-gcm)
           primitive (primitives/aead keyset-handle)
           aad (.getBytes "Salt")
           encrypted (sut/encrypt primitive
-                                 (.getBytes secret-data)
+                                 (.getBytes plain-text)
                                  aad)
           decrypted (sut/decrypt primitive
                                  encrypted
                                  aad)]
-      (is (= secret-data (String. decrypted))))))
+      (is (= plain-text (String. decrypted))))))


### PR DESCRIPTION
Issue: #21 

* Add the Hybrid Encryption example test all the code required as already there to create this example. :) 
* I have actively removed the .getBytes signature as the API should allow just byte arrays to be passed directly to the API. TODO make some wrapper for that .getBytes or we could check the signature on the API. 

