### PR TITLE
Bump version for SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,22 @@ Tinklj a Clojure api for [Google Tink](https://github.com/google/tink) cryptogra
 
 #### Leiningen/Boot
 ```
-[tinklj "0.1.1-SNAPSHOT"]
+[tinklj "0.1.2-SNAPSHOT"]
 ```
 #### Clojure CLI/deps.edn
 ```
-tinklj {:mvn/version "0.1.1-SNAPSHOT"}
+tinklj {:mvn/version "0.1.2-SNAPSHOT"}
 ```
 #### Gradle
 ```
-compile 'tinklj:tinklj:0.1.1-SNAPSHOT'
+compile 'tinklj:tinklj:0.1.2-SNAPSHOT'
 ```
 #### Maven
 ``` xml
 <dependency>
   <groupId>tinklj</groupId>
   <artifactId>tinklj</artifactId>
-  <version>0.1.1-SNAPSHOT</version>
+  <version>0.1.2-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject tinklj "0.1.1-SNAPSHOT"
+(defproject tinklj "0.1.2-SNAPSHOT"
   :description "A Clojure API for Google Tink Crypto Library. Offering a range of cryptographic techniques that are simple and easy to use."
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [com.google.crypto.tink/tink "1.3.0"]


### PR DESCRIPTION
@lamp 

Released version [0.1.1](https://clojars.org/tinklj/versions/0.1.1) with changes. 

Bump versions for snapshot. 0.1.2-SNAPSHOT
