### PR TITLE
Fixed AEAD :xchacha20-poly1305 and added test for it.

### DIFF
--- a/src/tinklj/keys/keyset_handle.clj
+++ b/src/tinklj/keys/keyset_handle.clj
@@ -15,8 +15,7 @@
                     :aes128-ctr-hmac-sha256 AeadKeyTemplates/AES128_CTR_HMAC_SHA256
                     :aes256-ctr-hmac-sha256 AeadKeyTemplates/AES256_CTR_HMAC_SHA256
                     :chacha20-poly1305 AeadKeyTemplates/CHACHA20_POLY1305
-                    ; This static property doesn't seem to exist on the class
-                    ; :xchacha20-poly1305 AeadKeyTemplates/XCHACHA20_POLY1305
+                    :xchacha20-poly1305 AeadKeyTemplates/XCHACHA20_POLY1305
                     :hmac-sha256-128bittag MacKeyTemplates/HMAC_SHA256_128BITTAG
                     :hmac-sha256-256bittag MacKeyTemplates/HMAC_SHA256_256BITTAG
                     :aes128-ctr-hmac-sha256-4kb StreamingAeadKeyTemplates/AES128_CTR_HMAC_SHA256_4KB

--- a/test/tinklj/acceptance/symmetric_key_encryption_test.clj
+++ b/test/tinklj/acceptance/symmetric_key_encryption_test.clj
@@ -7,17 +7,25 @@
 
 (register :aead)
 
-(deftest symmetric-key-encryption
-  (testing "Symmetric key encryption"
+(defn symmetric-key-encryption-test [the-key-template]
+  (let [plain-text "Secret data"
+        keyset-handle (keyset-handles/generate-new the-key-template)
+        primitive (primitives/aead keyset-handle)
+        aad (.getBytes "Salt")
+        encrypted (sut/encrypt primitive
+                               (.getBytes plain-text)
+                               aad)
+        decrypted (sut/decrypt primitive
+                               encrypted
+                               aad)]
+    (is (= plain-text (String. decrypted)))))
 
-    (let [plain-text "Secret data"
-          keyset-handle (keyset-handles/generate-new :aes128-gcm)
-          primitive (primitives/aead keyset-handle)
-          aad (.getBytes "Salt")
-          encrypted (sut/encrypt primitive
-                                 (.getBytes plain-text)
-                                 aad)
-          decrypted (sut/decrypt primitive
-                                 encrypted
-                                 aad)]
-      (is (= plain-text (String. decrypted))))))
+(deftest AES128_GCM-gcm-symmetric-key-encryption
+  (testing "AES128_GCM symmetric key encryption"
+
+    (symmetric-key-encryption-test :aes128-gcm)))
+
+(deftest XCHACHA20_POLY1305-gcm-symmetric-key-encryption
+  (testing "XCHACHA20_POLY1305 symmetric key encryption"
+
+    (symmetric-key-encryption-test :xchacha20-poly1305)))


### PR DESCRIPTION
The static property AeadKeyTemplates/XCHACHA20_POLY1305 referred to in src/tinklj/keys/keyset_handle.clj has been added to the class, had been commented out with  a note that it didn't "seem to exist on the class."  

Relatively mindlessly modified test, does it and the original :aes128-gcm.  Passes lein test and lein kaocha and failed manually testing wrong property name and failure of the encrypt to decrypt cycle.  